### PR TITLE
Refactored findFigureBehind()

### DIFF
--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/DefaultDrawing.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/DefaultDrawing.java
@@ -131,22 +131,7 @@ public class DefaultDrawing extends AbstractDrawing {
   }
 
   @Override
-  public Figure findFigureBehind(Point2D.Double p, Figure figure) {
-    boolean isBehind = false;
-    for (Figure f : getFiguresFrontToBack()) {
-      if (isBehind) {
-        if (f.isVisible() && f.contains(p)) {
-          return f;
-        }
-      } else {
-        isBehind = figure == f;
-      }
-    }
-    return null;
-  }
-
-  @Override
-  public Figure findFigureBehind(Point2D.Double p, double scaleDenominator, Figure figure) {
+  public Figure findFigureBehind(Point2D.Double p, Figure figure, double scaleDenominator) {
     boolean isBehind = false;
     for (Figure f : getFiguresFrontToBack()) {
       if (isBehind) {
@@ -161,20 +146,36 @@ public class DefaultDrawing extends AbstractDrawing {
   }
 
   @Override
-  public Figure findFigureBehind(Point2D.Double p, Collection<? extends Figure> children) {
-    int inFrontOf = children.size();
-    for (Figure f : getFiguresFrontToBack()) {
-      if (inFrontOf == 0) {
-        if (f.isVisible() && f.contains(p)) {
-          return f;
-        }
-      } else {
-        if (children.contains(f)) {
-          inFrontOf--;
+  public Figure findFigureBehind(Point2D.Double p, Object obj) {
+
+    if (obj instanceof Figure) {
+      boolean isBehind = false;
+      for (Figure f : getFiguresFrontToBack()) {
+        if (isBehind) {
+          if (f.isVisible() && f.contains(p)) {
+            return f;
+          }
+        } else {
+          isBehind = obj == f;
         }
       }
+      return null;
+    } else if (obj instanceof Collection) {
+
+      int inFrontOf = obj.size();
+      for (Figure f : getFiguresFrontToBack()) {
+        if (inFrontOf == 0) {
+          if (f.isVisible() && f.contains(p)) {
+            return f;
+          }
+        } else {
+          if (obj.contains(f)) {
+            inFrontOf--;
+          }
+        }
+      }
+      return null;
     }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
For the first and last findFigureBehind() that takes two paramaters, I replaced them with one method that checks the type of the second paramater , and based on being a Figure or a Colletion of Figures, code will be executed.

For the findFigureBehind() that takes 3 parameters, I rearranged the parameters so that developers do not have to rearrange them when adding a third parameter.
from
findFigureBehind( p ,scaleDenominator, figure )
to
findFigureBehind(p , figure, scaleDenominator )

because the other findFigureBehind() are arranged this way (p, figure)